### PR TITLE
Reimplement Quest Log for WoW 11.x Map & Quest UI integration

### DIFF
--- a/WoWJapanizer.lua
+++ b/WoWJapanizer.lua
@@ -1,7 +1,7 @@
 WoWJapanizer = LibStub("AceAddon-3.0"):NewAddon("WoWJapanizer", "AceConsole-3.0")
 
 WoWJapanizer.FONT = "Interface\\AddOns\\WoWJapanizer\\font\\ipagui.ttf";
-WoWJapanizer.DEBUG = false
+WoWJapanizer.DEBUG = false;
 
 WoWJapanizer.property = {}
 

--- a/WoWJapanizerQuestLog.lua
+++ b/WoWJapanizerQuestLog.lua
@@ -1,181 +1,605 @@
 WoWJapanizerQuestLog = WoWJapanizerQuest:New("WoWJapanizerQuestLog")
 
 WoWJapanizerQuestLog.QUEST_DATA_INFO_TEMPLATE = "Gnome Technology"
+WoWJapanizerQuestLog.japaneseFrame = nil
+WoWJapanizerQuestLog.toggleButton = nil
+WoWJapanizerQuestLog.showJapanese = true
+WoWJapanizerQuestLog.eventFrame = nil
+WoWJapanizerQuestLog._relayoutTicker = nil
+WoWJapanizerQuestLog.detailsFrame = nil
 
-isCarbonInitialized = false
+-- Helper function to find the DetailsFrame (try multiple paths)
+function WoWJapanizerQuestLog:GetDetailsFrame()
+    if self.detailsFrame then
+        return self.detailsFrame
+    end
+
+    if not QuestMapFrame then
+        print("WoWJapanizer: QuestMapFrame not found")
+        return nil
+    end
+
+    -- Try path 1: QuestMapFrame.QuestFrame.DetailsFrame
+    if QuestMapFrame.QuestFrame and QuestMapFrame.QuestFrame.DetailsFrame then
+        print("WoWJapanizer: Found DetailsFrame at QuestMapFrame.QuestFrame.DetailsFrame")
+        self.detailsFrame = QuestMapFrame.QuestFrame.DetailsFrame
+        return self.detailsFrame
+    end
+
+    -- Try path 2: QuestMapFrame.DetailsFrame (older version)
+    if QuestMapFrame.DetailsFrame then
+        print("WoWJapanizer: Found DetailsFrame at QuestMapFrame.DetailsFrame")
+        self.detailsFrame = QuestMapFrame.DetailsFrame
+        return self.detailsFrame
+    end
+
+    print("WoWJapanizer: DetailsFrame not found in any known location")
+    return nil
+end
 
 function WoWJapanizerQuestLog:OnInitialize()
-    WoWJapanizerQuestLogTitleText:SetText("WoWJapanizer")
-    WoWJapanizerQuestLogDataFrameText:SetFormattedText(self.QUEST_DATA_INFO_TEMPLATE, "unknown")
+    -- Create event frame for handling events
+    self.eventFrame = CreateFrame("Frame")
+    self.eventFrame:SetScript("OnEvent", function(frame, event, ...)
+        WoWJapanizerQuestLog:OnEvent(event, ...)
+    end)
 
-    self:Initialize()
-    self.ScrollFrame = _G[self.Frame:GetName() .. "ScrollFrame"]
-
-    self.QuestID =  _G[self.Frame:GetName() .. "QuestIdText"]
-    self.QuestID:SetPoint("TOPLEFT", 0, -3)
-	
     self:SetChecked(WoWJapanizer.db.profile.quest.questlog)
-
+    print("WoWJapanizer: Quest Log initialized")
 end
 
 function WoWJapanizerQuestLog:OnEnable()
-    WoWJapanizer:DebugLog("WoWJapanizerQuestLog: OnEnable.");
-    WoWJapanizerQuestLogDataFrameText:SetFormattedText(self.QUEST_DATA_INFO_TEMPLATE, "")
+    WoWJapanizer:DebugLog("WoWJapanizerQuestLog: OnEnable.")
+    print("WoWJapanizer: Quest Log module enabled")
 
-    self:SetMovable(WoWJapanizer.db.profile.quest.questlog_movable)
+    -- Try multiple hook methods for Quest selection
+    -- Method 1: Hook C_QuestLog events
+    self.eventFrame:RegisterEvent("QUEST_LOG_UPDATE")
+    self.eventFrame:RegisterEvent("QUEST_DETAIL")
 
-    if C_AddOns.IsAddOnLoaded("Carbonite") then
-		self:OnEnableCarbonite()
-        return
+    -- Method 2: Hook QuestMapFrame_ShowQuestDetails if it exists
+    if QuestMapFrame_ShowQuestDetails then
+        hooksecurefunc("QuestMapFrame_ShowQuestDetails", function(questID)
+            print("WoWJapanizer: QuestMapFrame_ShowQuestDetails called with questID:", questID)
+        end)
     end
 
-    if self:IsOldQuestGuru() then
-        self:OnEnableQuestGuru()
-    else
-         hooksecurefunc("QuestLogPopupDetailFrame_Show", function(questLogIndex)
-			WoWJapanizerQuestLog:QuestInfo()
-         end)
-		
+    -- Method 3: Hook QuestMapFrame directly (only if method exists)
+    if QuestMapFrame and type(QuestMapFrame.ShowQuestDetails) == "function" then
+        hooksecurefunc(QuestMapFrame, "ShowQuestDetails", function(self, questID)
+            print("WoWJapanizer: QuestMapFrame:ShowQuestDetails called with questID:", questID)
+        end)
     end
-	
-end
 
-function WoWJapanizerQuestLog:OnDisable()
-    WoWJapanizer:DebugLog("WoWJapanizerQuestLog: OnDisable.");
-end
+    -- Method 4: Hook C_QuestLog.SetSelectedQuest
+    hooksecurefunc(C_QuestLog, "SetSelectedQuest", function(questID)
+        print("WoWJapanizer: C_QuestLog.SetSelectedQuest called with questID:", questID)
+    end)
 
-function WoWJapanizerQuestLog:OnEnableCarbonite()
+    -- Hook DetailsFrame show/hide events to detect when quest details are displayed
+    C_Timer.After(1, function()
+        local df = self:GetDetailsFrame()
+        if df then
+            print("WoWJapanizer: Setting up DetailsFrame hooks")
 
-    hooksecurefunc("QuestInfo_Display", function(quest_template, ...)
-        if quest_template == QUEST_TEMPLATE_LOG then
-            WoWJapanizerQuestLog:QuestInfo()
+            df:HookScript("OnShow", function()
+                print("WoWJapanizer: DetailsFrame shown!")
+                WoWJapanizerQuestLog:OnDetailsFrameShow()
+            end)
+
+            df:HookScript("OnHide", function()
+                print("WoWJapanizer: DetailsFrame hidden!")
+                WoWJapanizerQuestLog:HideJapaneseFrame()
+            end)
+        else
+            print("WoWJapanizer: WARNING - Could not hook DetailsFrame events")
         end
     end)
 end
 
-function WoWJapanizerQuestLog:CarboniteCheck()
-
-	if isCarbonInitialized == true then
-		return
-	end
-	
-	if NXQuestLogDetailScrollChildFrame ~= nil then 
-		self.Frame:SetParent(NxQuestD)
-		self.Frame:SetPoint("TOPLEFT", NXQuestLogDetailScrollChildFrame, NXQuestLogDetailScrollChildFrame:GetWidth() + 75, 42)
-		self:ResizeFrame(512)
-		isCarbonInitialized = true
-	end
+function WoWJapanizerQuestLog:OnDisable()
+    WoWJapanizer:DebugLog("WoWJapanizerQuestLog: OnDisable.")
 end
 
-function WoWJapanizerQuestLog:QuestInfo()
-
-	self:CarboniteCheck()
-	
-    if not WoWJapanizerQuestLogShowJapanese:GetChecked() then
-        self.Frame:Hide()
-        return
-    end
-
-    local index = C_QuestLog.GetSelectedQuest()
-    if not index then
-        return
-    end
-
-	local info = C_QuestLog.GetInfo(index)
-	if not info then
-	    return
-	end
-
-	WoWJapanizer:DebugLog("WoWJapanizerQuestLog:QuestInfo: " .. info.questID)
-
-    if info.isHeader then
-        return
-    end
-
-    self:ShowDefault(info.questID)
-
-    if QuestNPCModel:IsShown() then
-        local point, relativeTo, relativePoint, xOffset, yOffset = QuestNPCModel:GetPoint(1) 
-        QuestNPCModel:SetPoint(point, self.Frame, relativePoint, 0, yOffset)
+function WoWJapanizerQuestLog:OnEvent(event, ...)
+    if event == "QUEST_LOG_UPDATE" then
+        -- Quest log was updated, only process if DetailsFrame is visible
+        local df = self:GetDetailsFrame()
+        if df and df:IsShown() then
+            local questID = C_QuestLog.GetSelectedQuest()
+            if questID and questID > 0 then
+                print("WoWJapanizer: QUEST_LOG_UPDATE - Selected quest:", questID)
+                self:ShowQuestDetails(questID)
+            end
+        end
+    elseif event == "QUEST_DETAIL" then
+        print("WoWJapanizer: QUEST_DETAIL event fired")
     end
 end
 
-function WoWJapanizerQuestLog:OnClickShowJapanese()
-    self:SetChecked(WoWJapanizerQuestLogShowJapanese:GetChecked())
-    if WoWJapanizerQuestLogShowJapanese:GetChecked() then
-        self:QuestInfo()
+function WoWJapanizerQuestLog:OnDetailsFrameShow()
+    print("WoWJapanizer: OnDetailsFrameShow called")
+
+    -- Create toggle button if it doesn't exist yet
+    if not self.toggleButton then
+        self:CreateToggleButton()
+    end
+
+    -- Create Japanese frame if it doesn't exist yet
+    if not self.japaneseFrame then
+        self:CreateJapaneseFrame()
+    end
+
+    -- Try initial layout when DetailsFrame is shown
+    self:LayoutJapaneseFrame()
+
+    -- Get the currently selected quest
+    local questID = C_QuestLog.GetSelectedQuest()
+    if questID and questID > 0 then
+        print("WoWJapanizer: Quest detail shown for questID:", questID)
+        self:ShowQuestDetails(questID)
     else
-        self.Frame:Hide()
+        print("WoWJapanizer: No quest selected")
     end
 end
 
-function WoWJapanizerQuestLog:IsOldQuestGuru()
-    if C_AddOns.IsAddOnLoaded("QuestGuru") then
-        local version = C_AddOns.GetAddOnMetadata("QuestGuru", "Version")
+function WoWJapanizerQuestLog:CreateToggleButton()
+    if self.toggleButton then
+        print("WoWJapanizer: Toggle button already exists")
+        return
+    end
 
-        if string.match(version, "^[01]") then
-            return true
+    print("WoWJapanizer: Creating toggle button...")
+
+    local df = self:GetDetailsFrame()
+    if not df then
+        print("WoWJapanizer: ERROR - Cannot create button, DetailsFrame not found")
+        return
+    end
+
+    local parent = df
+    local anchorPoint = "TOPLEFT"
+    local anchorX, anchorY = 10, -10
+
+    -- Try to find BackFrame and use it as parent
+    if df.BackFrame then
+        print("WoWJapanizer: BackFrame found, using it as parent")
+        parent = df.BackFrame
+
+        -- Debug: List all children of BackFrame
+        local children = {parent:GetChildren()}
+        print(string.format("WoWJapanizer: Found %d children in BackFrame", #children))
+        for i, child in ipairs(children) do
+            local name = child:GetName() or "unnamed"
+            local objType = child:GetObjectType()
+            print(string.format("  Child %d: %s (%s)", i, name, objType))
+        end
+
+        -- Try to anchor to the first child
+        if children[1] then
+            print(string.format("WoWJapanizer: Anchoring to first child: %s", children[1]:GetName() or "unnamed"))
+            local toggleBtn = CreateFrame("Button", "WoWJapanizerToggleButton", parent, "UIPanelButtonTemplate")
+            toggleBtn:SetSize(110, 22)
+            toggleBtn:SetPoint("LEFT", children[1], "RIGHT", 5, 0)
+            toggleBtn:SetText(self.showJapanese and "Japanese ON" or "Japanese OFF")
+            toggleBtn:SetScript("OnClick", function()
+                WoWJapanizerQuestLog:ToggleJapanese()
+            end)
+            self.toggleButton = toggleBtn
+            print("WoWJapanizer: Toggle button created in BackFrame!")
+            return
+        end
+    else
+        print("WoWJapanizer: BackFrame not found, using DetailsFrame as parent")
+
+        -- Debug: List all children of DetailsFrame
+        local children = {df:GetChildren()}
+        print(string.format("WoWJapanizer: Found %d children in DetailsFrame", #children))
+        for i, child in ipairs(children) do
+            local name = child:GetName() or "unnamed"
+            local objType = child:GetObjectType()
+            print(string.format("  Child %d: %s (%s)", i, name, objType))
         end
     end
 
-    return false
+    -- Create button in parent frame
+    local toggleBtn = CreateFrame("Button", "WoWJapanizerToggleButton", parent, "UIPanelButtonTemplate")
+    toggleBtn:SetSize(110, 22)
+    toggleBtn:SetPoint(anchorPoint, parent, anchorPoint, anchorX, anchorY)
+    toggleBtn:SetText(self.showJapanese and "Japanese ON" or "Japanese OFF")
+    toggleBtn:SetScript("OnClick", function()
+        WoWJapanizerQuestLog:ToggleJapanese()
+    end)
+
+    self.toggleButton = toggleBtn
+    print("WoWJapanizer: Toggle button created at default position!")
 end
 
-function WoWJapanizerQuestLog:OnEnableQuestGuru()
-    self.Frame:SetParent(QuestGuru_QuestLogDetailScrollFrame)
-    self.Frame:SetPoint("TOPLEFT", QuestGuru_QuestLogDetailScrollFrame, 330, 53);
+function WoWJapanizerQuestLog:CreateJapaneseFrame()
+    if self.japaneseFrame then
+        print("WoWJapanizer: Japanese frame already exists")
+        return
+    end
 
-    WoWJapanizerQuestLogShowJapanese:SetParent(QuestGuru_QuestFrameOptionsButton)
-    WoWJapanizerQuestLogShowJapanese:SetPoint("BOTTOMRIGHT", QuestGuru_QuestFrameOptionsButton, "BOTTOMRIGHT", -120 - WoWJapanizerQuestLogShowJapaneseText:GetWidth(), -2)
+    print("WoWJapanizer: Attempting to create Japanese frame...")
 
-    self:ResizeFrame(QuestGuru_QuestLogFrame:GetHeight())
+    local df = self:GetDetailsFrame()
+    if not df then
+        print("WoWJapanizer: ERROR - Cannot create Japanese frame, DetailsFrame not found")
+        return
+    end
 
-    for i=1, QUESTGURU_QUESTS_DISPLAYED do
-        button = _G["QuestGuru_QuestLogTitle" .. i]
-        button:HookScript("OnClick", function()
-            WoWJapanizerQuestLog:QuestInfo()
-        end)
+    print("WoWJapanizer: DetailsFrame found, creating frame...")
+
+    -- Create frame for Japanese translation
+    local frame = CreateFrame("Frame", "WoWJapanizerQuestDetailsFrame", df)
+
+    -- Try to position to the right of ScrollFrame if it exists
+    if df.ScrollFrame then
+        print("WoWJapanizer: Anchoring to ScrollFrame")
+        frame:SetPoint("BOTTOMLEFT", df.ScrollFrame, "BOTTOMRIGHT", 10, 0)
+        frame:SetPoint("TOPRIGHT", df, "TOPRIGHT", -10, -60)
+    else
+        print("WoWJapanizer: ScrollFrame not found, using default anchors")
+        frame:SetPoint("TOPLEFT", df, "TOPLEFT", 10, -60)
+        frame:SetPoint("BOTTOMRIGHT", df, "BOTTOMRIGHT", -10, 10)
+    end
+
+    frame:SetFrameStrata("HIGH")
+    frame:SetClampedToScreen(true)
+    frame:EnableMouse(false) -- do not block clicks on Blizzard UI by default
+    frame:Hide()
+
+    print("WoWJapanizer: Base frame created")
+
+    -- Background
+    frame.bg = frame:CreateTexture(nil, "BACKGROUND")
+    frame.bg:SetAllPoints()
+    frame.bg:SetColorTexture(0, 0, 0, 0.7)
+
+    -- Scroll frame for Japanese text
+    local scrollFrame = CreateFrame("ScrollFrame", nil, frame, "UIPanelScrollFrameTemplate")
+    scrollFrame:SetPoint("TOPLEFT", 10, -30)
+    scrollFrame:SetPoint("BOTTOMRIGHT", -30, 10)
+
+    -- Text content
+    local content = CreateFrame("Frame", nil, scrollFrame)
+    content:SetSize(scrollFrame:GetWidth() - 20, 1)
+    scrollFrame:SetScrollChild(content)
+
+    local text = content:CreateFontString(nil, "OVERLAY")
+    local fontSet = text:SetFont(WoWJapanizer.FONT, 12 + WoWJapanizer:FontSize())
+    if not fontSet then
+        print("WoWJapanizer: WARNING - Failed to set Japanese font, using default font")
+        text:SetFont("Fonts\\FRIZQT__.TTF", 12 + WoWJapanizer:FontSize())
+    else
+        print("WoWJapanizer: Japanese font set successfully:", WoWJapanizer.FONT)
+    end
+
+    text:SetPoint("TOPLEFT")
+    text:SetPoint("TOPRIGHT")
+    text:SetJustifyH("LEFT")
+    text:SetJustifyV("TOP")
+    text:SetTextColor(1, 1, 1)
+    text:SetSpacing(3)
+    text:SetWordWrap(true)
+    text:SetNonSpaceWrap(true)  -- Allow wrapping on Japanese characters
+
+    frame.scrollFrame = scrollFrame
+    frame.content = content
+    frame.text = text
+
+    self.japaneseFrame = frame
+    print("WoWJapanizer: Japanese frame created successfully!")
+end
+
+-- Helper: compute if two frames overlap on screen
+function WoWJapanizerQuestLog:FramesOverlap(a, b)
+    if not a or not b or not a.GetLeft or not b.GetLeft then return false end
+    local aL, aB, aW, aH = a:GetRect()
+    local bL, bB, bW, bH = b:GetRect()
+    if not aL or not bL then return false end
+    local aR, aT = aL + aW, aB + aH
+    local bR, bT = bL + bW, bB + bH
+    return not (aR <= bL or bR <= aL or aT <= bB or bT <= aB)
+end
+
+-- Helper: set default anchors relative to DetailsFrame
+function WoWJapanizerQuestLog:SetDefaultJapaneseAnchors()
+    if not self.japaneseFrame then return end
+
+    local df = self:GetDetailsFrame()
+    if not df then return end
+
+    local jf = self.japaneseFrame
+    jf:ClearAllPoints()
+    jf:SetParent(df)
+
+    if df.ScrollFrame then
+        jf:SetPoint("BOTTOMLEFT", df.ScrollFrame, "BOTTOMRIGHT", 10, 0)
+        jf:SetPoint("TOPRIGHT", df, "TOPRIGHT", -10, -60)
+    else
+        jf:SetPoint("TOPLEFT", df, "TOPLEFT", 10, -60)
+        jf:SetPoint("BOTTOMRIGHT", df, "BOTTOMRIGHT", -10, 10)
+    end
+
+    jf:SetFrameStrata("HIGH")
+    jf:SetFrameLevel(df:GetFrameLevel() + 20)
+end
+
+-- Layout logic: if a DetailsFrame child window overlaps our area, place the Japanese frame to its right
+-- otherwise keep default; if no space on the right, float above in front.
+function WoWJapanizerQuestLog:LayoutJapaneseFrame()
+    local jf = self.japaneseFrame
+    if not jf then return end
+
+    local df = self:GetDetailsFrame()
+    if not df then return end
+
+    -- Start with default anchors inside DetailsFrame
+    self:SetDefaultJapaneseAnchors()
+
+    -- Identify potential blocking child in DetailsFrame
+    local children = { df:GetChildren() }
+    local blocking = nil
+    for _, child in ipairs(children) do
+        if child ~= jf and child:IsShown() and child.GetRect then
+            -- ignore tiny elements like buttons/scrollbars
+            local l, b, w, h = child:GetRect()
+            if l and w and h and w > 80 and h > 80 then
+                if self:FramesOverlap(jf, child) then
+                    blocking = child
+                    break
+                end
+            end
+        end
+    end
+
+    if blocking then
+        -- Try to place to the right of the blocking frame in screen space
+        local bL, bB, bW, bH = blocking:GetRect()
+        if bL and bW then
+            local screenW, screenH = UIParent:GetSize()
+            local desiredLeft = bL + bW + 10
+            -- If there is room to the right, place there using UIParent as parent
+            if desiredLeft + 300 < screenW - 10 then
+                jf:ClearAllPoints()
+                jf:SetParent(UIParent)
+                jf:SetFrameStrata("DIALOG")
+                jf:SetFrameLevel(UIParent:GetFrameLevel() + 200)
+                -- Keep height similar to default; width up to 360 or remaining space
+                local width = math.min(360, screenW - desiredLeft - 10)
+                local top = math.min(bB + bH, screenH - 60)
+                jf:SetSize(width, df:GetHeight() - 60)
+                jf:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", desiredLeft, top)
+            else
+                -- No space: keep inside DetailsFrame but bring to front
+                jf:ClearAllPoints()
+                jf:SetParent(df)
+                jf:SetFrameStrata("DIALOG")
+                jf:SetFrameLevel(df:GetFrameLevel() + 200)
+                jf:SetPoint("BOTTOMLEFT", df.ScrollFrame, "BOTTOMRIGHT", 10, 0)
+                jf:SetPoint("TOPRIGHT", df, "TOPRIGHT", -10, -60)
+            end
+        end
+    end
+
+    -- Ensure text width recalculates after potential parent/size change
+    C_Timer.After(0, function()
+        if self.japaneseFrame and self.japaneseFrame.text and self.japaneseFrame.content and self.japaneseFrame.scrollFrame then
+            -- Update content and text width to match scrollFrame
+            local scrollWidth = self.japaneseFrame.scrollFrame:GetWidth()
+            local textWidth = math.max(scrollWidth - 40, 100)  -- Account for padding and scrollbar, minimum 100
+            self.japaneseFrame.content:SetWidth(textWidth)
+            self.japaneseFrame.text:SetWidth(textWidth)
+
+            -- Then recalculate height
+            local textHeight = self.japaneseFrame.text:GetStringHeight()
+            self.japaneseFrame.content:SetHeight(math.max(textHeight + 20, self.japaneseFrame.scrollFrame:GetHeight()))
+            print(string.format("WoWJapanizer: Layout updated - Text width: %d, height: %d", textWidth, textHeight))
+        end
+    end)
+end
+
+function WoWJapanizerQuestLog:ShowQuestDetails(questID)
+    print("WoWJapanizer: ShowQuestDetails called with questID:", questID)
+
+    -- Only process if DetailsFrame is actually shown
+    local df = self:GetDetailsFrame()
+    if not df or not df:IsShown() then
+        print("WoWJapanizer: DetailsFrame is not visible, skipping")
+        return
+    end
+
+    if not self.showJapanese or not WoWJapanizer:isShowQuest() then
+        print("WoWJapanizer: Japanese display disabled")
+        self:HideJapaneseFrame()
+        return
+    end
+
+    if not questID then
+        print("WoWJapanizer: No questID provided")
+        return
+    end
+
+    print("WoWJapanizer: Looking up Japanese translation for quest", questID)
+
+    local quest = WoWJapanizer_Quest:Get(questID)
+    if not quest then
+        print("WoWJapanizer: No Japanese translation found for quest", questID)
+        -- Fallback: show a short message instead of hiding the frame entirely
+        if not self.japaneseFrame then
+            self:CreateJapaneseFrame()
+        end
+        if self.japaneseFrame then
+            local msg = string.format("このクエスト (ID: %d) の日本語データが見つかりません。", questID)
+            self.japaneseFrame.text:SetText(msg)
+            self:LayoutJapaneseFrame()
+            local textHeight = self.japaneseFrame.text:GetStringHeight()
+            self.japaneseFrame.content:SetHeight(math.max(textHeight + 20, self.japaneseFrame.scrollFrame:GetHeight()))
+            self.japaneseFrame:Show()
+        end
+        return
+    end
+
+    print("WoWJapanizer: Japanese translation found!")
+
+    -- Build Japanese text
+    local player_name = UnitName("player")
+    local player_class = UnitClass("player")
+    local player_race = UnitRace("player")
+
+    local japaneseText = ""
+
+    -- Title
+    if quest.title and quest.title ~= "" then
+        japaneseText = japaneseText .. "|cFFFFD700" .. quest.title .. "|r\n\n"
+        print("WoWJapanizer: Title:", quest.title)
+    end
+
+    -- Objective
+    if quest.objective and quest.objective ~= "" then
+        local obj = string.gsub(quest.objective, "<name>", player_name)
+        obj = string.gsub(obj, "<class>", player_class)
+        obj = string.gsub(obj, "<race>", player_race)
+        japaneseText = japaneseText .. "|cFFFFFFFF目的:|r\n" .. obj .. "\n\n"
+        print("WoWJapanizer: Objective:", obj)
+    end
+
+    -- Description
+    if quest.description and quest.description ~= "" then
+        local desc = string.gsub(quest.description, "<name>", player_name)
+        desc = string.gsub(desc, "<class>", player_class)
+        desc = string.gsub(desc, "<race>", player_race)
+        japaneseText = japaneseText .. "|cFFFFFFFF説明:|r\n" .. desc .. "\n\n"
+        print("WoWJapanizer: Description:", desc)
+    end
+
+    -- Progress
+    if quest.progress and quest.progress ~= "" then
+        local prog = string.gsub(quest.progress, "<name>", player_name)
+        prog = string.gsub(prog, "<class>", player_class)
+        prog = string.gsub(prog, "<race>", player_race)
+        japaneseText = japaneseText .. "|cFFFFFFFF進行:|r\n" .. prog .. "\n\n"
+        print("WoWJapanizer: Progress:", prog)
+    end
+
+    -- Completion
+    if quest.completion and quest.completion ~= "" then
+        local comp = string.gsub(quest.completion, "<name>", player_name)
+        comp = string.gsub(comp, "<class>", player_class)
+        comp = string.gsub(comp, "<race>", player_race)
+        japaneseText = japaneseText .. "|cFFFFFFFF完了:|r\n" .. comp .. "\n"
+        print("WoWJapanizer: Completion:", comp)
+    end
+
+    print("WoWJapanizer: Full Japanese text length:", string.len(japaneseText))
+
+    if japaneseText ~= "" then
+        -- For now, just print to chat - no UI frame
+        print("WoWJapanizer: ========== Quest Translation ==========")
+        print(japaneseText)
+        print("WoWJapanizer: =======================================")
+
+        -- Create frame if it doesn't exist yet
+        if not self.japaneseFrame then
+            print("WoWJapanizer: Creating Japanese frame...")
+            self:CreateJapaneseFrame()
+        end
+
+        if self.japaneseFrame then
+            print("WoWJapanizer: Displaying Japanese frame")
+
+            -- Set the text
+            self.japaneseFrame.text:SetText(japaneseText)
+            print("WoWJapanizer: Text set, length:", string.len(japaneseText))
+
+            -- Re-layout around any blocking UI each time we show
+            self:LayoutJapaneseFrame()
+
+            -- Ensure text width is set correctly after layout
+            C_Timer.After(0.1, function()
+                if self.japaneseFrame and self.japaneseFrame.text then
+                    local scrollWidth = self.japaneseFrame.scrollFrame:GetWidth()
+                    local textWidth = scrollWidth - 40  -- Account for padding and scrollbar
+                    self.japaneseFrame.content:SetWidth(textWidth)
+
+                    -- Force text to update its dimensions
+                    self.japaneseFrame.text:SetWidth(textWidth)
+
+                    -- Now get the actual height needed
+                    local textHeight = self.japaneseFrame.text:GetStringHeight()
+                    print(string.format("WoWJapanizer: Text dimensions - Width: %d, Height: %d", textWidth, textHeight))
+
+                    self.japaneseFrame.content:SetHeight(math.max(textHeight + 40, self.japaneseFrame.scrollFrame:GetHeight()))
+                end
+            end)
+
+            -- Initial height calculation
+            local textHeight = self.japaneseFrame.text:GetStringHeight()
+            self.japaneseFrame.content:SetHeight(math.max(textHeight + 20, self.japaneseFrame.scrollFrame:GetHeight()))
+
+            self.japaneseFrame:Show()
+            print("WoWJapanizer: Japanese frame is now shown")
+            -- While visible, re-check layout a few times in case Blizzard UI animates in
+            if self._relayoutTicker then self._relayoutTicker:Cancel() end
+            self._relayoutTicker = C_Timer.NewTicker(0.5, function()
+                if not self.japaneseFrame or not self.japaneseFrame:IsShown() then
+                    if self._relayoutTicker then self._relayoutTicker:Cancel() end
+                    self._relayoutTicker = nil
+                    return
+                end
+                self:LayoutJapaneseFrame()
+            end, 6) -- run a few times then stop
+        else
+            print("WoWJapanizer: ERROR - Could not create Japanese frame")
+        end
+    else
+        print("WoWJapanizer: No Japanese text to display")
+        self:HideJapaneseFrame()
     end
 end
 
-function WoWJapanizerQuestLog:ResizeFrame(height)
-    if height > 512 then
-        height = 512
+function WoWJapanizerQuestLog:HideJapaneseFrame()
+    if self.japaneseFrame then
+        self.japaneseFrame:Hide()
+    end
+    if self._relayoutTicker then
+        self._relayoutTicker:Cancel()
+        self._relayoutTicker = nil
+    end
+end
+
+function WoWJapanizerQuestLog:ToggleJapanese()
+    self.showJapanese = not self.showJapanese
+    print("WoWJapanizer: Toggle Japanese -", self.showJapanese and "ON" or "OFF")
+
+    -- Update button text
+    if self.toggleButton then
+        if self.showJapanese then
+            self.toggleButton:SetText("Japanese ON")
+        else
+            self.toggleButton:SetText("Japanese OFF")
+        end
     end
 
-    self.Frame:SetHeight(height)
-    self.ScrollFrame:SetHeight(height - 104)
-
-    height = height - 256
-    local bl = _G[self.Frame:GetName() .. "BottomLeft"]
-    bl:SetHeight(height)
-    bl:SetTexCoord(0, 1, ((256 - height) / 256), 1)
-
-    local br = _G[self.Frame:GetName() .. "BottomRight"]
-    br:SetHeight(height)
-    br:SetTexCoord(0, 1, ((256 - height) / 256), 1)
+    if self.showJapanese then
+        -- Refresh current quest
+        local questID = C_QuestLog.GetSelectedQuest()
+        if questID and questID > 0 then
+            print("WoWJapanizer: Refreshing quest", questID)
+            self:ShowQuestDetails(questID)
+        else
+            print("WoWJapanizer: No quest selected")
+        end
+    else
+        self:HideJapaneseFrame()
+    end
 end
 
 function WoWJapanizerQuestLog:SetChecked(check)
-    WoWJapanizerQuestLogShowJapanese:SetChecked(check)
-end
-
-function WoWJapanizerQuestLog:SetMovable(movable)
-    self.Frame:SetMovable(movable)
-    if movable then
-        self.Frame:RegisterForDrag("LeftButton")
-    end
-end
-
-function WoWJapanizerQuestLog:OnDragStart()
-    if self.Frame:IsMovable() then
-        self.Frame:StartMoving()
-    end
-end
-
-function WoWJapanizerQuestLog:OnDragStop()
-    if self.Frame:IsMovable() then
-        self.Frame:StopMovingOrSizing()
-        ValidateFramePosition(self.Frame)
+    self.showJapanese = check
+    if self.toggleButton then
+        self.toggleButton:SetText(self.showJapanese and "Japanese ON" or "Japanese OFF")
     end
 end


### PR DESCRIPTION
## Description

This PR completely reimplements the WoWJapanizerQuestLog module to support World of Warcraft 11.x's modern Quest UI system.

### Key Changes

- **Complete rewrite for WoW 11.x compatibility**: Rebuilt from the ground up to work with the current Map & Quest UI architecture
- **Dynamic DetailsFrame detection**: Implements flexible frame detection with multiple fallback paths to ensure compatibility across different UI configurations
- **Japanese translation toggle**: Adds an interactive button to switch between original and Japanese quest text
- **Enhanced translation display**: New dedicated frame for displaying Japanese translations alongside quest details
- **Modern event handling**: Properly hooks into DetailsFrame events for reliable quest detail tracking
- **Code cleanup**: Removed obsolete legacy addon compatibility code (Carbonite, QuestGuru, etc.)

### Technical Improvements

- Replaces hardcoded frame references with dynamic detection system
- Implements robust error handling for frame detection failures
- Modernizes event hook patterns for better stability
- Streamlines codebase by removing deprecated compatibility layers

### Testing

Tested on WoW 11.x with the new Quest UI system. The translation toggle and display functions work correctly with quest details.

![CleanShot 2025-11-18 at 05 59 17](https://github.com/user-attachments/assets/ac9f21d8-1b7c-4daf-bc90-fb844aa4003f)
