### PR TITLE
Update version numbering from v5.x.x to v0.x.x (development stage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Available options:
 
 ## Version History
 
-### 5.0.1
+### 0.4.19 (Development - Current)
+- **Note**: This is a development version. Version numbering starts at 0.4.19 to indicate early development stage.
 - Complete rewrite for WoW 11.x (The War Within)
 - New integrated Map & Quest Log UI support
 - Migrated to modern WoW APIs (C_QuestLog, C_AddOns, TooltipDataProcessor)
@@ -77,7 +78,7 @@ Available options:
 - Rebranded as WoWJapanizerX for a separate CurseForge release
 
 ### 4.19 (Legacy)
-- Last version supporting WoW 7.1.0 (Legion expansion)
+- Last version of original WoWJapanizer supporting WoW 7.1.0 (Legion expansion)
 - Original WoWJapanizer by milai
 
 ## Development
@@ -165,7 +166,7 @@ This project continues the work of the original WoWJapanizer addon. Please respe
 
 ## Links
 
-- [CurseForge](https://www.curseforge.com/wow/addons/wowjapanizerx) (coming soon)
+- [CurseForge](https://www.curseforge.com/wow/addons/wowjapanizerx)
 - [Original WoWJapanizer](https://www.curseforge.com/wow/addons/wowjapanizer) (legacy)
 - [Report Issues](https://github.com/x5gtrn/WoWJapanizerX/issues)
 

--- a/WoWJapanizerX.toc
+++ b/WoWJapanizerX.toc
@@ -1,7 +1,7 @@
 ## Interface: 110205
 ## Title: WoWJapanizerX
 ## Notes: Translate Quest data, Item ToolTips and Spell ToolTips into Japanese text.
-## Version: 5.0.0
+## Version: 0.4.19
 ## Author: x5gtrn
 ## OptionalDeps: Ace3, LibStub, CallbackHandler
 ## SavedVariables: WoWJapanizerXDB


### PR DESCRIPTION
This PR updates the version numbering scheme to better reflect the current development stage of WoWJapanizerX.

### Changes Made

- **Version Update**: Changed the version from `5.0.0` or `5.0.1` to `0.4.19`
  - Updated in `WoWJapanizerX.toc`
  - Updated in `README.md` version history section

### Rationale

The previous version number (5.0.1) suggested a stable, mature release. However, WoWJapanizerX is still in active development for WoW 11.x (The War Within). The new versioning scheme (0.4.19) more accurately represents:

- **Early development stage** (0.x indicates pre-1.0 development)
- **Continued iteration** on features and stability
- **Clear communication** to users that the addon is under active development

### Documentation Updates

- Added a development status note to README.md
- Clarified version history to distinguish between legacy WoWJapanizer (4.19) and current WoWJapanizerX development
- Maintained changelog for transparency

### Impact

- **No functional changes** to the addon
- Better sets user expectations regarding development status
- Aligns with semantic versioning best practices for pre-release software
