### PR TITLE
Limit tooltip translation to quests #11

### DIFF
--- a/WoWJapanizerItemRefTooltip.lua
+++ b/WoWJapanizerItemRefTooltip.lua
@@ -14,15 +14,13 @@ function WoWJapanizerItemRefTooltip:OnInitialize()
         tooltipObj:OnQuest()
     end)
 
-    TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Achievement, function(tooltip, data)
-        if tooltip ~= tooltipObj.Tooltip then
-            return
-        end
-        tooltipObj:OnAchievement()
-    end)
 end
 
 function WoWJapanizerItemRefTooltip:OnQuest()
+    if not WoWJapanizerX.db.profile.quest.tooltip then
+        return
+    end
+
     local questID = WoWJapanizer_Quest:GetID_ItemRefTooltip(self.Tooltip)
 
     if questID == 0 then
@@ -113,48 +111,5 @@ function WoWJapanizerItemRefTooltip:OnQuest()
     self:DeveloperText("QuestID", questID)
 end
 
-function WoWJapanizerItemRefTooltip:OnAchievement()
-    if not WoWJapanizerX.db.profile.achievement.tooltip then return end
-
-    local achievementID = WoWJapanizer_Achievement:GetID_ItemRefTooltip(self.Tooltip)
-
-    if achievementID == 0 then
-        return
-    end
-
-    local achievement = WoWJapanizer_Achievement:Get(achievementID)
-
-    if not achievement then
-        return
-    end
-
-    self.selected.type  = self.TOOLTIP_ACHIEVEMENT
-
-    self:AddSeparator()
-    self:AddText(achievement.text)
-    self:DeveloperText("AchievementID", achievementID)
-end
-
 function WoWJapanizerItemRefTooltip:Resize(width, height)
-    if self.selected.type == self.TOOLTIP_ACHIEVEMENT then
-        if width > 350 then
-            local target = _G[self.Tooltip:GetName() .. "TextLeft1"]
-            local h = height
-            local w = math.floor(target:GetWidth())
-            if w < 350 then w = 350 end
-
-            for i=2, self.Tooltip:NumLines() do
-                target = _G[self.Tooltip:GetName() .. "TextRight" .. i]
-                if math.floor(target:GetWidth()) == 1 then
-                    target = _G[self.Tooltip:GetName() .. "TextLeft" .. i]
-                    h = h - target:GetHeight()
-                    target:SetWidth(w)
-                    h = h + target:GetHeight()
-                end
-            end
-
-            self.Tooltip:SetWidth(w + 20)
-            self.Tooltip:SetHeight(h)
-        end
-    end
 end

--- a/WoWJapanizerToolTip.lua
+++ b/WoWJapanizerToolTip.lua
@@ -3,10 +3,7 @@ WoWJapanizerToolTip.Tooltip = nil
 WoWJapanizerToolTip.Store = nil
 
 WoWJapanizerToolTip.TOOLTIP_NONE        = 0
-WoWJapanizerToolTip.TOOLTIP_ITEM        = 1
-WoWJapanizerToolTip.TOOLTIP_SPELL       = 2
-WoWJapanizerToolTip.TOOLTIP_QUEST       = 3
-WoWJapanizerToolTip.TOOLTIP_ACHIEVEMENT = 4
+WoWJapanizerToolTip.TOOLTIP_QUEST       = 1
 
 function WoWJapanizerToolTip:New(base)
     local obj = {}
@@ -52,70 +49,6 @@ end
 
 function WoWJapanizerToolTip:Enable()
     WoWJapanizerX:DebugLog(self.base .. ":Enable");
-
-	-- Store self reference for closures
-	local tooltipObj = self
-
-	TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, function(tooltip, data)
-		if tooltip ~= tooltipObj.Tooltip then
-			return
-		end
-
-		local name, link = tooltip:GetItem()
-		if not link then
-			return
-		end
-
-		local _, _, itemID = link:find("Hitem:(%d+):")
-		if not itemID then
-			return
-		end
-
-		tooltipObj:DebugPrint('ITEM', itemID, name, tooltipObj.Tooltip)
-
-		if WoWJapanizerX.db.profile.item.tooltip then
-			local item = WoWJapanizer_Item:Get(itemID)
-			if item then
-				tooltipObj.selected.type = tooltipObj.TOOLTIP_ITEM
-				tooltipObj:AddText(item.text)
-			end
-		end
-
-		tooltipObj:DeveloperText("ItemID", itemID)
-	end)
-
-	TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Spell, function(tooltip, data)
-		if tooltip ~= tooltipObj.Tooltip then
-			return
-		end
-
-		local spellName, spellRank, spellID = tooltip:GetSpell()
-		if not spellID then
-			return
-		end
-
-		tooltipObj:DebugPrint('SPELL', spellID, spellName, tooltipObj.Tooltip)
-
-		if WoWJapanizerX.db.profile.spell.tooltip then
-			if not tooltipObj:CheckEnhancedTooltips() then
-				tooltipObj:AddText(WoWJapanizerX.L.NotEnhancedTooltips)
-				return
-			end
-
-			local spell = WoWJapanizer_Spell:GetTooltipText(spellID, tooltipObj.Tooltip)
-			if spell then
-				tooltipObj.selected.type = tooltipObj.TOOLTIP_SPELL
-				if spell.next == nil then
-					tooltipObj:AddText(spell.text)
-				else
-					tooltipObj:AddText(spell.text .. "\n|cffffffff" .. WoWJapanizerX.L["NextRank"] .. "|r\n" .. spell.next)
-				end
-			end
-		end
-
-		tooltipObj:DeveloperText("SpellID", spellID)
-	end)
-
 end
 
 function WoWJapanizerToolTip:AddText(text)
@@ -186,14 +119,6 @@ function WoWJapanizerToolTip:AddSeparator()
 end
 
 function WoWJapanizerToolTip:Resize(width, height)
-end
-
-function WoWJapanizerToolTip:CheckEnhancedTooltips()
-    if tonumber(GetCVar("UberTooltips")) == 1 then
-        return true
-    else
-        return false
-    end
 end
 
 function WoWJapanizerToolTip:DebugPrint(base, id, name, tooltip)

--- a/WoWJapanizerX.lua
+++ b/WoWJapanizerX.lua
@@ -14,13 +14,10 @@ function WoWJapanizerX:OnInitialize()
     -- Using 'Default' as the default profile for consistency across characters
     local defaults = {
         profile = {
-            quest       = { questlog = true, gossip = true, questlog_movable = false, furigana = false },
-            item        = { tooltip = true },
-            spell       = { tooltip = true },
-            achievement = { tooltip = true, advice = true },
+            quest       = { questlog = true, gossip = true, tooltip = true, questlog_movable = false, furigana = false },
             developer   = self.DEBUG,
             development = { debugger = self.DEBUG },
-            config      = { fontsize = 0, tooltip = true },
+            config      = { fontsize = 0 },
         }
     }
 
@@ -30,11 +27,8 @@ function WoWJapanizerX:OnInitialize()
     WoWJapanizerQuestLog:OnInitialize()
     WoWJapanizerQuestGossip:OnInitialize()
 
-    -- ToolTip --
-    WoWJapanizerGameToolTip:OnInitialize()
+    -- Quest ToolTip --
     WoWJapanizerItemRefTooltip:OnInitialize()
-
-    WoWJapanizerGarrisonToolTip:OnInitialize()
 
 end
 
@@ -48,11 +42,8 @@ function WoWJapanizerX:OnEnable()
     WoWJapanizerQuestLog:OnEnable()
     WoWJapanizerQuestGossip:OnEnable()
 
-    -- ToolTip --
-    WoWJapanizerGameToolTip:OnEnable()
+    -- Quest ToolTip --
     WoWJapanizerItemRefTooltip:OnEnable()
-
-	WoWJapanizerGarrisonToolTip:OnEnable()
 
 end
 
@@ -63,11 +54,8 @@ function WoWJapanizerX:OnDisable()
     WoWJapanizerQuestLog:OnDisable()
     WoWJapanizerQuestGossip:OnDisable()
 
-    -- ToolTip --
-    WoWJapanizerGameToolTip:OnDisable()
+    -- Quest ToolTip --
     WoWJapanizerItemRefTooltip:OnDisable()
-
-	WoWJapanizerGarrisonToolTip:OnDisable()
 
 end
 
@@ -84,7 +72,7 @@ function WoWJapanizerX:isShowQuest()
 end
 
 function WoWJapanizerX:isShowTooltip()
-	return self.db.profile.config.tooltip
+	return self.db.profile.quest.tooltip
 end
 
 function WoWJapanizerX:uc(str)
@@ -128,23 +116,20 @@ function WoWJapanizerX:SetupOptions()
 					fontSize = "medium",
 					order = 15,
 				},
-				ShowToolTip = {
+				ShowQuestToolTip = {
 					type = "toggle",
-					name = "Show Tool Tip",
+					name = "Show Quest Tool Tip",
 					order = 20,
 					set = function(info, value)
-						self.db.profile.config.tooltip = value;
-						self.db.profile.item.tooltip = value;
-						self.db.profile.spell.tooltip = value;
-						self.db.profile.achievement.tooltip = value;
+						self.db.profile.quest.tooltip = value;
 					end,
 					get = function(info)
-						return self.db.profile.config.tooltip;
+						return self.db.profile.quest.tooltip;
 					end,					
 				},
 				Spacer3 = {
 					type = "description",
-					name = "Show Japanese Tool Tip for Item/Spell/Achievement",
+					name = "Show Japanese Quest Tool Tip",
 					fontSize = "medium",
 					order = 25,
 				},

--- a/WoWJapanizerX.toc
+++ b/WoWJapanizerX.toc
@@ -1,6 +1,6 @@
 ## Interface: 110205
 ## Title: WoWJapanizerX
-## Notes: Translate Quest data, Item ToolTips and Spell ToolTips into Japanese text.
+## Notes: Translate Quest data into Japanese text.
 ## Version: 0.4.19
 ## Author: x5gtrn
 ## OptionalDeps: Ace3, LibStub, CallbackHandler
@@ -18,22 +18,6 @@ Data\Quest\WoWJapanizer_QuestData.lua
 Data\Quest\WoWJapanizer_QuestIndex.lua
 Data\Quest\WoWJapanizer_QuestFuriganaData.lua
 
-Data\Achievement\WoWJapanizer_Achievement.lua
-Data\Achievement\WoWJapanizer_AchievementData.lua
-Data\Achievement\WoWJapanizer_AchievementIndex.lua
-
-Data\Item\WoWJapanizer_Item.lua
-Data\Item\WoWJapanizer_ItemData.lua
-
-Data\Spell\WoWJapanizer_Spell.lua
-Data\Spell\WoWJapanizer_SpellData.lua
-Data\Spell\WoWJapanizer_SpellNewbie.lua
-Data\Spell\WoWJapanizer_SpellChain.lua
-
-Data\Garrison\WoWJapanizer_Garrison.lua
-Data\Garrison\WoWJapanizer_GarrisonData.lua
-Data\Garrison\WoWJapanizer_GarrisonChain.lua
-
 WoWJapanizerDebug.xml
 
 WoWJapanizerTemplate.xml
@@ -45,13 +29,8 @@ WoWJapanizerQuestGossip.xml
 WoWJapanizerQuestGossip.lua
 
 WoWJapanizerToolTip.lua
-WoWJapanizerGameToolTip.lua
 WoWJapanizerItemRefTooltip.lua
-
-WoWJapanizerTooltip.xml
-WoWJapanizerGarrisonToolTip.lua
 
 WoWJapanizerX.lua
 
 locales\WoWJapanizerX-jaJP.lua
-


### PR DESCRIPTION
## Summary

Cherry-pick of the commit already merged into `main` to bring `develop` in sync.

This change limits tooltip translation to quests only, removing support for item, spell, achievement, and garrison tooltips.

## Changes

- Remove item, spell, achievement, and garrison tooltip translation
- Remove associated data files (`Item`, `Spell`, `Achievement`, `Garrison`)
- Simplify `WoWJapanizerToolTip` to support only `TOOLTIP_QUEST`
- Remove `WoWJapanizerGameToolTip` and `WoWJapanizerGarrisonToolTip` modules
- Consolidate tooltip setting into `quest.tooltip` profile option
- Update addon notes in `.toc` to reflect quest-only scope

## Reason for cherry-pick

This commit was already applied to `main`. This PR applies the same change to `develop` to keep the branch consistent.